### PR TITLE
goFetch-1: Add Colors to output

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os/user"
 	"strings"
 
+	"github.com/M-Faheem-Khan/goFetch/utils"
 	"github.com/zcalusic/sysinfo"
 )
 
@@ -14,12 +15,12 @@ func main() {
 
 	header, divider := generateHeader(si)
 
-	fmt.Println(header)
-	fmt.Println(divider)
-	fmt.Printf("OS: %s\n", si.OS.Name)
-	fmt.Printf("Kernel: %s\n", si.Kernel.Release)
-	fmt.Printf("CPU: %s\n", si.CPU.Model)
-	fmt.Printf("Memory: %dmb\n", si.Memory.Size)
+	fmt.Println(utils.FormatHeaderString(header))
+	fmt.Println(utils.FormatBoldString(divider))
+	fmt.Printf("%s: %s\n", utils.FormatKeyString("OS"), si.OS.Name)
+	fmt.Printf("%s: %s\n", utils.FormatKeyString("Kernel"), si.Kernel.Release)
+	fmt.Printf("%s: %s\n", utils.FormatKeyString("CPU"), si.CPU.Model)
+	fmt.Printf("%s: %d mb\n", utils.FormatKeyString("Memory"), si.Memory.Size)
 }
 
 func generateHeader(si sysinfo.SysInfo) (string, string) {
@@ -44,3 +45,5 @@ func join(strs ...string) string {
 	}
 	return sb.String()
 }
+
+// EOF - Changes should reflect

--- a/utils/colors.go
+++ b/utils/colors.go
@@ -1,0 +1,22 @@
+package utils
+
+// colors.go - Coloring and formatting configuration and helper functions.
+
+var headerString string = "\033[33m"
+var boldString string = "\033[32m"
+var keyString string = "\033[95m"
+var endFormatting string = "\033[0m"
+
+func FormatHeaderString(s string) string {
+	return headerString + s + endFormatting
+}
+
+func FormatBoldString(s string) string {
+	return boldString + s + endFormatting
+}
+
+func FormatKeyString(s string) string {
+	return keyString + s + endFormatting
+}
+
+// EOF


### PR DESCRIPTION
Addresses: #1 

- Add colour to output (see images below)

| Key | Color |
|----|----|
| headerString | "\033[33m" - Yellow|
| boldString | "\033[32m" - Green|
| keyString | "\033[95m" - Purple |
| endFormatting | "\033[0m" - End Formatting Character |

<img width="261" alt="Screenshot 2023-02-16 at 9 42 17 PM" src="https://user-images.githubusercontent.com/17150767/219845950-448378b5-9a34-43db-b1a7-00ab179c4a22.png">

![Screenshot 2023-02-17 at 11 44 01 PM](https://user-images.githubusercontent.com/17150767/219845952-3ff766ed-338d-488c-88bf-1a126827d620.png)
